### PR TITLE
fix when upload files,and one file is completed then the leave page c…

### DIFF
--- a/src/uploader.coffee
+++ b/src/uploader.coffee
@@ -19,7 +19,7 @@ class Uploader extends SimpleModule
       @files.splice($.inArray(file, @files), 1)
       if @queue.length > 0 and @files.length < @opts.connectionCount
         @upload @queue.shift()
-      else
+      else if @files.length == 0
         @uploading = false
 
     # confirm to leave page while uploading


### PR DESCRIPTION
修复当多个文件上传的时候，有一个文件已经上传了，还有一个文件还在上传，那么离开该页面的confirm就不会出现了